### PR TITLE
update for mpoly v1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: mvp
 Type: Package
 Title: Fast Symbolic Multivariate Polynomials
-Version: 1.0-4
-Date: 2019-01-11
+Version: 1.0-5
+Date: 2019-01-29
 Author: Robin K. S. Hankin
 Depends: methods,magrittr
-Suggests: knitr,rmarkdown,spray
+Suggests: knitr,rmarkdown,spray,microbenchmark
 VignetteBuilder: knitr
 Maintainer: Robin K. S. Hankin <hankin.robin@gmail.com>
 Description: Fast manipulation of symbolic multivariate polynomials
@@ -15,7 +15,10 @@ Description: Fast manipulation of symbolic multivariate polynomials
   speed improvements.  It is comparable in speed to the 'spray' package
   for sparse arrays, but retains the symbolic benefits of 'mpoly'.
 License: GPL (>= 2)
-Imports: Rcpp (>= 0.12.3),partitions,mpoly,magic
+Imports: Rcpp (>= 0.12.3),
+  partitions,
+  mpoly (>= 1.1.0),
+  magic
 LinkingTo: Rcpp
 SystemRequirements: C++11
 URL: https://github.com/RobinHankin/mvp.git

--- a/tests/aac.R
+++ b/tests/aac.R
@@ -4,7 +4,7 @@
 library("mvp")
 
 
-P <- as.mvp("1+x+x^3*z+4x^2*y+ 4*z^4")^3
+P <- as.mvp("1 + x + x^3 z + 4 x^2 y + 4 z^4")^3
 stopifnot(aderiv(P,x=1,y=2,z=3) == aderiv(P,z=3,x=1,y=2))
 
 

--- a/tests/foursquare.R
+++ b/tests/foursquare.R
@@ -10,10 +10,10 @@ LHS <- as.mvp(
 )
 
 RHS <- as.mvp("
-   (a1*b1-a2*b2-a3*b3-a4*b4)^2
-  +(a1*b2+a2*b1+a3*b4-a4*b3)^2
-  +(a1*b3-a2*b4+a3*b1+a4*b2)^2
-  +(a1*b4+a2*b3-a3*b2+a4*b1)^2
+   (a1*b1-a2*b2-a3*b3-a4*b4)^2 +
+   (a1*b2+a2*b1+a3*b4-a4*b3)^2 +
+   (a1*b3-a2*b4+a3*b1+a4*b2)^2 +
+   (a1*b4+a2*b3-a3*b2+a4*b1)^2
 ")
 
 stopifnot(LHS==RHS)

--- a/vignettes/mvp.Rmd
+++ b/vignettes/mvp.Rmd
@@ -79,8 +79,7 @@ representation in the following R session:
 
 ```{r}
 library("mvp",quietly=TRUE)
-p <- as.mvp("3x y + z^3 + x y^6 z")
-p
+(p <- as.mvp("3 x y + z^3 + x y^6 z"))
 ```
 
 Coercion and printing are accomplished by the ```mpoly``` package
@@ -99,8 +98,7 @@ the symbols within a single term.  Although this might sound odd, if
 we consider a marginally more involved situation, such as
 
 ```{r}
-M <- as.mvp("3 stoat*goat^6 -4 + 7 stoatboat^3 * bloat -9 float*boat*goat*gloat^6")
-M
+(M <- as.mvp("3 stoat goat^6 -4 + 7 stoatboat^3 bloat -9 float boat goat gloat^6"))
 dput(M)
 ```
 
@@ -121,12 +119,10 @@ The arithmetic operations ```*```, ```+```, ```-``` and ```^``` work
 as expected:
 
 ```{r}
-S1 <- rmvp(5,2,2,4)
-S2 <- rmvp(5,2,2,4)
-S1
-S2
-S1+S2
-S1*S2
+(S1 <- rmvp(5,2,2,4))
+(S2 <- rmvp(5,2,2,4))
+S1 + S2
+S1 * S2
 S1^2
 ```
 
@@ -137,21 +133,20 @@ substitute one or more variables for a numeric value.  Define a mvp
 object:
 
 ```{r}
-S3 <- as.mvp("x + 5x^4*y + 8y^2*x*z^3")
-S3
+(S3 <- as.mvp("x + 5 x^4 y + 8 y^2 x z^3"))
 ```
 
 And then we may substitute $x=1$:
 
 ```{r}
-subs(S3,x=1)
+subs(S3, x = 1)
 ```
 
 Note the natural R idiom, and that the return value is another mvp
 object.  We may subsitute for the other variables:
 
 ```{r}
-subs(S3,x=1,y=2,z=3)
+subs(S3, x = 1, y = 2, z = 3)
 ```
 
 (in this case, the default behaviour is to return a "dropped" version
@@ -159,7 +154,7 @@ of the resulting polynomial, that is, coerced to a scalar).  The other
 mode of substitution is to replace a variable by another polynomial:
 
 ```{r}
-subsmvp(S3,"z",as.mvp("a^2+2b^3"))
+subsmvp(S3,"z", as.mvp("a^2 + 2 b^3"))
 ```
 
 ## Differentiation
@@ -168,17 +163,16 @@ Differentiation is implemented.  First we have the ```deriv()```
 method:
 
 ```{r}
-S <- rmvp(5,4,6,4)
-S
-deriv(S,letters[1:3])
-deriv(S,rev(letters[1:3]))  # should be the same.
+(S <- rmvp(5,4,6,4))
+deriv(S, letters[1:3])
+deriv(S, rev(letters[1:3]))  # should be the same.
 ```
 
 Also a slightly different form:```aderiv()```, here used to evaluate
 $\frac{\partial^6S}{\partial a^3\partial b\partial c^2}$:
 
 ```{r}
-aderiv(S,a=3,b=1,c=2)
+aderiv(S, a = 3, b = 1, c = 2)
 ```
 
 ## Negative powers
@@ -187,8 +181,7 @@ The ```mvp``` package handles negative powers, although the idiom is not perfect
 There is the ```invert()``` function:
 
 ```{r}
-p <- as.mvp("1+x+x^2 y")
-p
+(p <- as.mvp("1+x+x^2 y"))
 invert(p)
 ```
 
@@ -222,18 +215,20 @@ exploits the symbolic nature of the ```mvp``` package.
 ```{r}
 library("spray")
 library("mpoly")
-n <- 500
-k <- kahle(n,r=3,p=1:3,symbols=paste("x",sprintf("%03d",seq_len(n)),sep=""))
+n <- 100
+k <- kahle(n, r = 3, p = 1:3, symbols = paste0("x", sprintf("%03d", 1:n)))
 ```
 
 In the above, polynomial ```k``` has 500 terms of the form $xy^2z^3$.
 Coercing ```k``` to ```spray``` form would need a $500\times 500$
 matrix for the indices, almost every element of which would be zero.
-This makes the spray package slower:
+This makes [the __spray__ package](https://github.com/RobinHankin/spray) slower:
 
 ```{r}
-system.time(ignore <- k^2)
-system.time(ignore <- mvp_to_spray(k)^2) 
+library("microbenchmark")
+
+spray_k <- mvp_to_spray(k)
+microbenchmark( k^2, spray_k^2 )
 ```
 
 In the above, the first line uses ```mvp``` functionality, and the


### PR DESCRIPTION
This should fix the little bugs in __mvp__ caused by the upgrading of __mpoly__ to `1.1.0`, although I'm not sure why things like `4x` parsed properly before. In any case, please give it a look/check. From my side, `R CMD check --as-cran mvp_1.0-5.tar.gz` is clean. Thanks, Robin!